### PR TITLE
Load chruby in your .zshrc

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -8,3 +8,7 @@ export LC_CTYPE=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 
 export EDITOR="atom"
+
+# chruby
+source /usr/local/opt/chruby/share/chruby/chruby.sh
+source /usr/local/opt/chruby/share/chruby/auto.sh


### PR DESCRIPTION
Fixes auto switching when entering a project directory that
has a `.ruby-version` file.